### PR TITLE
Only add translations to enabled dictionaries

### DIFF
--- a/plover_console_ui/add_translation.py
+++ b/plover_console_ui/add_translation.py
@@ -38,7 +38,7 @@ class AddTranslation:
         self.dicts = []
         for path in self.engine.dictionaries:
             d = self.engine.dictionaries[path]
-            if not d.readonly:
+            if not d.readonly and d.enabled:
                 self.dicts.append(d)
 
         self.dict_index = 0


### PR DESCRIPTION
This fix makes it so adding translations will add them to the highest
priority enabled dictionary instead of the highest priority dictionary.

The previous behaviour would add a new entry to `foo.json` if the
dictionary stack looked like:

```
1. foo.json DISABLED
2. user.json ENABLED
3. main.json ENABLED
```

Whereas the new behaviour will add the entry to `main.json` instead.
